### PR TITLE
Using binary mode to open source in put method

### DIFF
--- a/cloudmesh/oracle/storage/Provider.py
+++ b/cloudmesh/oracle/storage/Provider.py
@@ -263,7 +263,7 @@ class Provider(StorageABC):
             self.object_storage.put_object(self.namespace,
                                            self.bucket_name,
                                            str(trimmed_destination),
-                                           open(trimmed_source, 'r'))
+                                           open(trimmed_source, 'rb'))
 
             # make head call since file upload does not return
             # obj dict to extract meta data


### PR DESCRIPTION
Execution of test_storage_copy failed on file created with Benchmark.file(source, size). Using binary mode to open source in put method.